### PR TITLE
Wait between different databases

### DIFF
--- a/tests/kronicler-sqlite-comparison/tests/simple_concurrent.py
+++ b/tests/kronicler-sqlite-comparison/tests/simple_concurrent.py
@@ -117,6 +117,9 @@ if __name__ == "__main__":
         print(f"{avg_sqlite.__name__} took {end - start}ns")
         avg_times_data.append((avg_sqlite.__name__, end - start))
 
+        # Wait for any cleanup to happen between SQLite and Columnar
+        time.sleep(2)
+
         # TEST columnar inserts
         start = time.time_ns()
         test_columnar()
@@ -132,6 +135,9 @@ if __name__ == "__main__":
         end = time.time_ns()
         print(f"{avg_columnar.__name__} took {end - start}ns")
         avg_times_data.append((avg_columnar.__name__, end - start))
+
+        # Wait for any cleanup to happen between Columnar and No log
+        time.sleep(2)
 
         # TEST no log inserts
         start = time.time_ns()

--- a/tests/kronicler-sqlite-comparison/tests/simple_sync.py
+++ b/tests/kronicler-sqlite-comparison/tests/simple_sync.py
@@ -115,6 +115,9 @@ if __name__ == "__main__":
         print(f"{avg_sqlite.__name__} took {end - start}ns")
         avg_times_data.append((avg_sqlite.__name__, end - start))
 
+        # Wait for any cleanup to happen between SQLite and Columnar
+        time.sleep(2)
+
         # TEST columnar inserts
         start = time.time_ns()
         test_columnar()
@@ -128,6 +131,9 @@ if __name__ == "__main__":
         end = time.time_ns()
         print(f"{avg_columnar.__name__} took {end - start}ns")
         avg_times_data.append((avg_columnar.__name__, end - start))
+
+        # Wait for any cleanup to happen between Columnar and No log
+        time.sleep(2)
 
         # TEST no log inserts
         start = time.time_ns()


### PR DESCRIPTION
This wait allows any process to finish after the writes to a given database. I've noticed some problems where the database insert speeds will have correlated spikes, and I think the SQLite tests are slowing down the columnar tests.